### PR TITLE
Add: Missing general class for all spacings at once (padding, margin)

### DIFF
--- a/assets/styles/utilities/_spacings.scss
+++ b/assets/styles/utilities/_spacings.scss
@@ -16,10 +16,12 @@
 
 /* Prefix classes for spacings */
 $spacing-classes: (
+	'p': padding,
 	'pt': padding-top,
 	'pb': padding-bottom,
 	'pr': padding-right,
 	'pl': padding-left,
+	'm': margin,
 	'mt': margin-top,
 	'mb': margin-bottom,
 	'mr': margin-right,


### PR DESCRIPTION
Add: Missing general class for all spacings at once (padding, margin)

Before “p0”, “m0” class names weren’t working. Now, you’re able to add
“padding: 0” and “margin: 0” with those class names.